### PR TITLE
Fix `restcountries` API

### DIFF
--- a/seo/demo/pages/index.js
+++ b/seo/demo/pages/index.js
@@ -74,7 +74,7 @@ export default function Start({ countries }) {
 
           <ul className={styles.countries}>
             {results.map((country) => (
-              <li key={country.alpha2Code} className={styles.country}>
+              <li key={country.cca2} className={styles.country}>
                 <p>
                   {country.name} - {country.population.toLocaleString()}
                 </p>
@@ -113,12 +113,16 @@ export default function Start({ countries }) {
 }
 
 export async function getServerSideProps() {
-  const response = await fetch("https://restcountries.eu/rest/v2/all")
+  const response = await fetch("https://restcountries.com/v3.1/all")
   const countries = await response.json()
 
   return {
     props: {
-      countries
+      countries: countries.map((country) => ({
+        name: country.name.common,
+        cca2: country.cca2,
+        population: country.population,
+      })),
     }
   }
 }

--- a/seo/pages/index.js
+++ b/seo/pages/index.js
@@ -63,7 +63,7 @@ export default function Start({ countries }) {
 
           <ul className={styles.countries}>
             {results.map((country) => (
-              <li key={country.alpha2Code} className={styles.country}>
+              <li key={country.cca2} className={styles.country}>
                 <p>
                   {country.name} - {country.population.toLocaleString()}
                 </p>
@@ -100,12 +100,16 @@ export default function Start({ countries }) {
 }
 
 export async function getServerSideProps() {
-  const response = await fetch('https://restcountries.eu/rest/v2/all');
+  const response = await fetch('https://restcountries.com/v3.1/all');
   const countries = await response.json();
 
   return {
     props: {
-      countries,
+      countries: countries.map((country) => ({
+        name: country.name.common,
+        cca2: country.cca2,
+        population: country.population,
+      })),
     },
   };
 }


### PR DESCRIPTION
Updated the `restcountries` API from `v2` to `v3.1`. Also added a map over the countries data before returning the data to the page, so that the size of page props lowers to `13.7kb` from `714kb`, which is much better for performance.

Fixes https://github.com/vercel/next-learn/issues/52