### PR TITLE
Update posts.js

### DIFF
--- a/basics/dynamic-routes-starter/lib/posts.js
+++ b/basics/dynamic-routes-starter/lib/posts.js
@@ -6,7 +6,7 @@ const postsDirectory = path.join(process.cwd(), 'posts')
 
 export function getSortedPostsData() {
   // Get file names under /posts
-  const fileNames = fs.readdirSync(postsDirectory)
+  const fileNames = fs.readdirSync(postsDirectory).filter(e=>e!=="[id].js")
   const allPostsData = fileNames.map(fileName => {
     // Remove ".md" from file name to get id
     const id = fileName.replace(/\.md$/, '')


### PR DESCRIPTION
The following line should return all markdown posts, but it also returns the [id].js file which causes some problems, such as throwing an error because it doesn't have a date to be parsed by the date.js component.

const fileNames = fs.readdirSync(postsDirectory)

I find that the following code easily fix this:

 const fileNames = fs.readdirSync(postsDirectory).filter(e=>e!=="[id].js")