### PR TITLE
Missing Dependency on `lean-starter`

### DIFF
--- a/basics/learn-starter/package.json
+++ b/basics/learn-starter/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "next": "latest",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "styled-jsx": "^5.0.2
   }
 }


### PR DESCRIPTION
It doesn't automagically work when using the tutorial in: https://nextjs.org/learn/basics/create-nextjs-app/setup