### PR TITLE
Update all project dependencies

### DIFF
--- a/basics/api-routes-starter/package.json
+++ b/basics/api-routes-starter/package.json
@@ -8,9 +8,9 @@
   "dependencies": {
     "date-fns": "^2.11.1",
     "gray-matter": "^4.0.2",
-    "next": "latest",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "next": "12.3.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "remark": "^14.0.1",
     "remark-html": "^15.0.0"
   }

--- a/basics/assets-metadata-css-starter/package.json
+++ b/basics/assets-metadata-css-starter/package.json
@@ -6,8 +6,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "latest",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "next": "12.3.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   }
 }

--- a/basics/basics-final/package.json
+++ b/basics/basics-final/package.json
@@ -8,9 +8,9 @@
   "dependencies": {
     "date-fns": "^2.11.1",
     "gray-matter": "^4.0.2",
-    "next": "latest",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "next": "12.3.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "remark": "^14.0.1",
     "remark-html": "^15.0.0"
   }

--- a/basics/data-fetching-starter/package.json
+++ b/basics/data-fetching-starter/package.json
@@ -6,8 +6,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "latest",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "next": "12.3.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   }
 }

--- a/basics/demo/package.json
+++ b/basics/demo/package.json
@@ -8,9 +8,9 @@
   "dependencies": {
     "date-fns": "^2.11.1",
     "gray-matter": "^4.0.2",
-    "next": "latest",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "next": "12.3.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "remark": "^14.0.1",
     "remark-html": "^15.0.0"
   }

--- a/basics/dynamic-routes-starter/package.json
+++ b/basics/dynamic-routes-starter/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "gray-matter": "^4.0.2",
-    "next": "latest",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "next": "12.3.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   }
 }

--- a/basics/dynamic-routes-step-1/package.json
+++ b/basics/dynamic-routes-step-1/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "gray-matter": "^4.0.2",
-    "next": "latest",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "next": "12.3.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   }
 }

--- a/basics/learn-starter/package.json
+++ b/basics/learn-starter/package.json
@@ -6,8 +6,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "latest",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "next": "12.3.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   }
 }

--- a/basics/navigate-between-pages-starter/package.json
+++ b/basics/navigate-between-pages-starter/package.json
@@ -6,8 +6,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "latest",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "next": "12.3.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   }
 }

--- a/basics/typescript-final/package.json
+++ b/basics/typescript-final/package.json
@@ -8,9 +8,9 @@
   "dependencies": {
     "date-fns": "^2.11.1",
     "gray-matter": "^4.0.2",
-    "next": "latest",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "next": "12.3.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "remark": "^14.0.1",
     "remark-html": "^15.0.0"
   },

--- a/seo/demo/package.json
+++ b/seo/demo/package.json
@@ -8,9 +8,9 @@
   "dependencies": {
     "fuse.js": "^6.4.6",
     "lodash": "^4.17.21",
-    "next": "latest",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "next": "12.3.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "react-modal": "^3.12.1",
     "react-syntax-highlighter": "^15.4.3"
   }

--- a/seo/package.json
+++ b/seo/package.json
@@ -8,9 +8,9 @@
   "dependencies": {
     "fuse.js": "^6.4.6",
     "lodash": "^4.17.21",
-    "next": "latest",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "next": "12.3.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "react-modal": "^3.12.1",
     "react-syntax-highlighter": "^15.4.3"
   }


### PR DESCRIPTION
Update all `next` dependencies to prevent error below from happening. For instance, when trying to [learn Next.js](https://nextjs.org/learn) for the first time (like me!).

Fixes #90 and all other projects that were ready for `12.x` or prior versions but not `13.x`.

<img width="799" alt="image" src="https://user-images.githubusercontent.com/20128985/198706221-e2059c14-6576-46a0-884f-cb0477f6aeb4.png">
