### PR TITLE
next latest is not compatible with react 17

### DIFF
--- a/basics/learn-starter/package.json
+++ b/basics/learn-starter/package.json
@@ -7,7 +7,5 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
   }
 }


### PR DESCRIPTION
I started learning next js today and quickly became stuck by having the recommended command fail due to a dependency mismatch. Since next already has react and react-dom as a peer dependency, by deleting the explicit reference to react and react-dom I was able to continue with the tutorial. A different solution would be to explicitly peg react 18, but I worry a similar breakage would occur in the future.