### PR TITLE
Consistency between part 1 and 2 of the tutorial

### DIFF
--- a/basics/navigate-between-pages-starter/pages/index.js
+++ b/basics/navigate-between-pages-starter/pages/index.js
@@ -11,7 +11,7 @@ export default function Home() {
 
       <main>
         <h1 className={styles.title}>
-          Welcome to <a href="https://nextjs.org">Next.js!</a>
+          Learn <a href="https://nextjs.org">Next.js!</a>
         </h1>
 
         <p className={styles.description}>


### PR DESCRIPTION
Make it consistent with the changes the user has made in the first part of the tutorial "Create a Next.js App".  Also some changes required in the learn nextjs docs ( Which for some reason are not editable in github?) 

from 
```
<h1 className="title">
  Welcome to <a href="https://nextjs.org">Next.js!</a>
</h1>
```

To 
```
<h1 className={styles.title}>
  Learn <a href="https://nextjs.org">Next.js!</a>
</h1>
```


Also relates to this issue
https://github.com/vercel/next.js/issues/47479