### PR TITLE
Fix pagination bugs and refactor/abstract styling logic

### DIFF
--- a/dashboard/15-final/app/dashboard/customers/page.tsx
+++ b/dashboard/15-final/app/dashboard/customers/page.tsx
@@ -4,12 +4,10 @@ import CustomersTable from '@/app/ui/customers/table';
 export default async function Page({
   searchParams,
 }: {
-  searchParams:
-    | {
-        query: string | undefined;
-        page: string | undefined;
-      }
-    | undefined;
+  searchParams?: {
+    query?: string;
+    page?: string;
+  };
 }) {
   const query = searchParams?.query || '';
 

--- a/dashboard/15-final/app/dashboard/invoices/page.tsx
+++ b/dashboard/15-final/app/dashboard/invoices/page.tsx
@@ -14,7 +14,7 @@ export default async function Page({
   };
 }) {
   const query = searchParams?.query || '';
-  const currentPage = query ? 1 : Number(searchParams?.page || '1');
+  const currentPage = Number(searchParams?.page || '1');
 
   const { invoices, totalPages } = await fetchFilteredInvoices(
     query,

--- a/dashboard/15-final/app/dashboard/invoices/page.tsx
+++ b/dashboard/15-final/app/dashboard/invoices/page.tsx
@@ -8,12 +8,10 @@ import { lusitana } from '@/app/ui/fonts';
 export default async function Page({
   searchParams,
 }: {
-  searchParams:
-    | {
-        query: string | undefined;
-        page: string | undefined;
-      }
-    | undefined;
+  searchParams?: {
+    query?: string;
+    page?: string;
+  };
 }) {
   const query = searchParams?.query || '';
   const currentPage = query ? 1 : Number(searchParams?.page || '1');

--- a/dashboard/15-final/app/lib/utils.ts
+++ b/dashboard/15-final/app/lib/utils.ts
@@ -34,3 +34,27 @@ export const generateYAxis = (revenue: Revenue[]) => {
 
   return { yAxisLabels, topLabel };
 };
+
+export const generatePagination = (currentPage: number, totalPages: number) => {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  if (currentPage <= 3) {
+    return [1, 2, 3, '...', totalPages - 1, totalPages];
+  }
+
+  if (currentPage >= totalPages - 2) {
+    return [1, 2, '...', totalPages - 2, totalPages - 1, totalPages];
+  }
+
+  return [
+    1,
+    '...',
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+    '...',
+    totalPages,
+  ];
+};

--- a/dashboard/15-final/app/lib/utils.ts
+++ b/dashboard/15-final/app/lib/utils.ts
@@ -36,18 +36,27 @@ export const generateYAxis = (revenue: Revenue[]) => {
 };
 
 export const generatePagination = (currentPage: number, totalPages: number) => {
+  // If the total number of pages is 7 or less,
+  // display all pages without any ellipsis.
   if (totalPages <= 7) {
     return Array.from({ length: totalPages }, (_, i) => i + 1);
   }
 
+  // If the current page is among the first 3 pages,
+  // show the first 3, an ellipsis, and the last 2 pages.
   if (currentPage <= 3) {
     return [1, 2, 3, '...', totalPages - 1, totalPages];
   }
 
+  // If the current page is among the last 3 pages,
+  // show the first 2, an ellipsis, and the last 3 pages.
   if (currentPage >= totalPages - 2) {
     return [1, 2, '...', totalPages - 2, totalPages - 1, totalPages];
   }
 
+  // If the current page is somewhere in the middle,
+  // show the first page, an ellipsis, the current page and its neighbors,
+  // another ellipsis, and the last page.
   return [
     1,
     '...',

--- a/dashboard/15-final/app/ui/invoices/pagination.tsx
+++ b/dashboard/15-final/app/ui/invoices/pagination.tsx
@@ -4,6 +4,7 @@ import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
 import { usePathname, useSearchParams } from 'next/navigation';
 import clsx from 'clsx';
 import Link from 'next/link';
+import { generatePagination } from '@/app/lib/utils';
 
 export default function Pagination({
   currentPage,
@@ -25,25 +26,7 @@ export default function Pagination({
     return `${pathname}?${params.toString()}`;
   };
 
-  let pagesToShow = [];
-
-  if (totalPages <= 7) {
-    pagesToShow = allPages;
-  } else if (currentPage <= 3) {
-    pagesToShow = [1, 2, 3, '...', totalPages - 1, totalPages];
-  } else if (currentPage >= totalPages - 2) {
-    pagesToShow = [1, 2, '...', totalPages - 2, totalPages - 1, totalPages];
-  } else {
-    pagesToShow = [
-      1,
-      '...',
-      currentPage - 1,
-      currentPage,
-      currentPage + 1,
-      '...',
-      totalPages,
-    ];
-  }
+  const allPages = generatePagination(currentPage, totalPages);
 
   return (
     <div className="inline-flex">

--- a/dashboard/15-final/app/ui/invoices/pagination.tsx
+++ b/dashboard/15-final/app/ui/invoices/pagination.tsx
@@ -34,10 +34,11 @@ export default function Pagination({
 
       <div className="flex -space-x-px">
         {allPages.map((page, index) => {
-          let position: 'first' | 'last' | 'middle' | undefined;
+          let position: 'first' | 'last' | 'single' | 'middle' | undefined;
 
           if (index === 0) position = 'first';
           if (index === allPages.length - 1) position = 'last';
+          if (allPages.length === 1) position = 'single';
           if (page === '...') position = 'middle';
 
           return (
@@ -69,14 +70,14 @@ function PaginationNumber({
 }: {
   page: number | string;
   href: string;
-  position?: 'first' | 'last' | 'middle';
+  position?: 'first' | 'last' | 'middle' | 'single';
   isActive: boolean;
 }) {
   const className = clsx(
     'flex h-10 w-10 items-center justify-center text-sm border',
     {
-      'rounded-l-md': position === 'first',
-      'rounded-r-md': position === 'last',
+      'rounded-l-md': position === 'first' || position === 'single',
+      'rounded-r-md': position === 'last' || position === 'single',
       'z-10 bg-blue-600 border-blue-600 text-white': isActive,
       'hover:bg-gray-100': !isActive && position !== 'middle',
       'text-gray-300': position === 'middle',

--- a/dashboard/15-final/app/ui/invoices/pagination.tsx
+++ b/dashboard/15-final/app/ui/invoices/pagination.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
-import { usePathname, useSearchParams } from 'next/navigation';
 import clsx from 'clsx';
 import Link from 'next/link';
 import { generatePagination } from '@/app/lib/utils';
+import { usePathname, useSearchParams } from 'next/navigation';
 
 export default function Pagination({
   currentPage,
@@ -16,11 +16,7 @@ export default function Pagination({
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const allPages = Array.from({ length: totalPages }, (_, i) => i + 1);
-  const PreviousPageTag = Link;
-  const NextPageTag = Link;
-
-  const createPageUrl = (pageNumber: number | string) => {
+  const createPageURL = (pageNumber: number | string) => {
     const params = new URLSearchParams(searchParams);
     params.set('page', pageNumber.toString());
     return `${pathname}?${params.toString()}`;
@@ -30,8 +26,9 @@ export default function Pagination({
 
   return (
     <div className="inline-flex">
-      <PreviousPageTag
-        href={createPageUrl(currentPage - 1)}
+      {/* Previous Page Arrow */}
+      <Link
+        href={createPageURL(currentPage - 1)}
         className={clsx(
           'mr-2 flex h-10 w-10 items-center justify-center rounded-md ring-1 ring-inset ring-gray-300 hover:bg-gray-100 md:mr-4',
           {
@@ -41,9 +38,9 @@ export default function Pagination({
         )}
       >
         <ArrowLeftIcon className="w-4" />
-      </PreviousPageTag>
+      </Link>
       <div className="flex -space-x-px ">
-        {pagesToShow.map((page, i) => {
+        {allPages.map((page, i) => {
           if (page === '...') {
             return (
               <span
@@ -59,10 +56,10 @@ export default function Pagination({
           return (
             <PageTag
               key={page}
-              href={createPageUrl(page)}
+              href={createPageURL(page)}
               className={clsx(
                 i === 0 && 'rounded-l-md',
-                i === pagesToShow.length - 1 && 'rounded-r-md',
+                i === allPages.length - 1 && 'rounded-r-md',
                 'flex h-10 w-10 items-center justify-center text-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-100',
                 {
                   'z-10 bg-blue-600 text-white ring-blue-600 hover:bg-blue-600':
@@ -75,8 +72,9 @@ export default function Pagination({
           );
         })}
       </div>
-      <NextPageTag
-        href={createPageUrl(currentPage + 1)}
+      {/* Next Page Arrow */}
+      <Link
+        href={createPageURL(currentPage + 1)}
         className={clsx(
           'ml-2 flex h-10 w-10 items-center justify-center rounded-md ring-1 ring-inset ring-gray-300 hover:bg-gray-100 md:ml-4',
           {
@@ -85,7 +83,7 @@ export default function Pagination({
         )}
       >
         <ArrowRightIcon className="w-4" />
-      </NextPageTag>
+      </Link>
     </div>
   );
 }

--- a/dashboard/15-final/app/ui/invoices/pagination.tsx
+++ b/dashboard/15-final/app/ui/invoices/pagination.tsx
@@ -26,64 +26,103 @@ export default function Pagination({
 
   return (
     <div className="inline-flex">
-      {/* Previous Page Arrow */}
-      <Link
+      <PaginationArrow
+        direction="left"
         href={createPageURL(currentPage - 1)}
-        className={clsx(
-          'mr-2 flex h-10 w-10 items-center justify-center rounded-md ring-1 ring-inset ring-gray-300 hover:bg-gray-100 md:mr-4',
-          {
-            'pointer-events-none text-gray-300 hover:bg-transparent':
-              currentPage === 1,
-          },
-        )}
-      >
-        <ArrowLeftIcon className="w-4" />
-      </Link>
-      <div className="flex -space-x-px ">
-        {allPages.map((page, i) => {
-          if (page === '...') {
-            return (
-              <span
-                key={`ellipsis-${i}`}
-                className="flex h-10 w-10 items-center justify-center text-sm ring-1 ring-inset ring-gray-300"
-              >
-                ...
-              </span>
-            );
-          }
+        isDisabled={currentPage <= 1}
+      />
 
-          const PageTag = page === currentPage || page === '...' ? 'p' : Link;
+      <div className="flex -space-x-px">
+        {allPages.map((page, index) => {
+          let position: 'first' | 'last' | 'middle' | undefined;
+
+          if (index === 0) position = 'first';
+          if (index === allPages.length - 1) position = 'last';
+          if (page === '...') position = 'middle';
+
           return (
-            <PageTag
+            <PaginationNumber
               key={page}
               href={createPageURL(page)}
-              className={clsx(
-                i === 0 && 'rounded-l-md',
-                i === allPages.length - 1 && 'rounded-r-md',
-                'flex h-10 w-10 items-center justify-center text-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-100',
-                {
-                  'z-10 bg-blue-600 text-white ring-blue-600 hover:bg-blue-600':
-                    currentPage === page,
-                },
-              )}
-            >
-              {page}
-            </PageTag>
+              page={page}
+              position={position}
+              isActive={currentPage === page}
+            />
           );
         })}
       </div>
-      {/* Next Page Arrow */}
-      <Link
+
+      <PaginationArrow
+        direction="right"
         href={createPageURL(currentPage + 1)}
-        className={clsx(
-          'ml-2 flex h-10 w-10 items-center justify-center rounded-md ring-1 ring-inset ring-gray-300 hover:bg-gray-100 md:ml-4',
-          {
-            'text-gray-300': currentPage === totalPages,
-          },
-        )}
-      >
-        <ArrowRightIcon className="w-4" />
-      </Link>
+        isDisabled={currentPage >= totalPages}
+      />
     </div>
+  );
+}
+
+function PaginationNumber({
+  page,
+  href,
+  isActive,
+  position,
+}: {
+  page: number | string;
+  href: string;
+  position?: 'first' | 'last' | 'middle';
+  isActive: boolean;
+}) {
+  const className = clsx(
+    'flex h-10 w-10 items-center justify-center text-sm border',
+    {
+      'rounded-l-md': position === 'first',
+      'rounded-r-md': position === 'last',
+      'z-10 bg-blue-600 border-blue-600 text-white': isActive,
+      'hover:bg-gray-100': !isActive && position !== 'middle',
+      'text-gray-300': position === 'middle',
+    },
+  );
+
+  return isActive || position === 'middle' ? (
+    <div className={className}>{page}</div>
+  ) : (
+    <Link href={href} className={className}>
+      {page}
+    </Link>
+  );
+}
+
+function PaginationArrow({
+  href,
+  direction,
+  isDisabled,
+}: {
+  href: string;
+  direction: 'left' | 'right';
+  isDisabled?: boolean;
+}) {
+  const className = clsx(
+    'flex h-10 w-10 items-center justify-center rounded-md border',
+    {
+      'pointer-events-none text-gray-300': isDisabled,
+      'hover:bg-gray-100': !isDisabled,
+      'mr-2 md:mr-4': direction === 'left',
+      'ml-2 md:ml-4': direction === 'right',
+    },
+  );
+
+  const icon =
+    direction === 'left' ? (
+      <ArrowLeftIcon className="w-4" />
+    ) : (
+      <ArrowRightIcon className="w-4" />
+    );
+
+  return isDisabled ? (
+    <div className={className}>{icon}</div>
+  ) : (
+    <Link className={className} href={href}>
+      {icon}
+    </Link>
   );
 }

--- a/dashboard/15-final/app/ui/search.tsx
+++ b/dashboard/15-final/app/ui/search.tsx
@@ -13,6 +13,8 @@ export default function Search({ placeholder }: { placeholder: string }) {
     console.log(`Searching... ${term}`);
 
     const params = new URLSearchParams(searchParams);
+
+    params.set('page', '1');
     if (term) {
       params.set('query', term);
     } else {


### PR DESCRIPTION
This PR fixes the pagination bugs:

1. We were using `pointer-events-none` to disable arrows for the first and last pages, but this only disables mouse events - keyboard users could navigate to `page=0` or `page=totalPages + 1`. This PR truly disables them by rendering a `<div>` instead of a `<Link>`. It also means we're not passing a href to disabled links.  

<img width="1614" alt="CleanShot 2023-10-09 at 13 32 56@2x" src="https://github.com/vercel/next-learn/assets/32464864/ab4b3d0a-0ebc-4d9a-8f33-a24cf0c5a913">

2. Fixes hover states. Removes hover state on active items, removes hover state on disabled items.
3. Disable ellipsis.  
4. Fixes border styles.

<img width="456" alt="CleanShot 2023-10-09 at 14 03 47@2x" src="https://github.com/vercel/next-learn/assets/32464864/cb739125-5418-484a-bff2-1b4040632d39">

5. Fix bug where you could not click on subsequent pages if a search term existed (since the page would always default to 1)

I've also extracted away the logic into separate components to make it easier for the user to update the `<Pagination>` component. 


