### PR TITLE
Fix dashboard project missing output font

### DIFF
--- a/dashboard/final-example/app/ui/fonts/index.ts
+++ b/dashboard/final-example/app/ui/fonts/index.ts
@@ -1,0 +1,5 @@
+import { Lusitana } from 'next/font/google';
+
+export const lusitana = Lusitana({
+  weight: ['400'],
+});

--- a/dashboard/final-example/app/ui/fonts/index.ts
+++ b/dashboard/final-example/app/ui/fonts/index.ts
@@ -2,4 +2,5 @@ import { Lusitana } from 'next/font/google';
 
 export const lusitana = Lusitana({
   weight: ['400'],
+  subsets: ['latin'],
 });

--- a/dashboard/starter-example/app/ui/fonts/index.ts
+++ b/dashboard/starter-example/app/ui/fonts/index.ts
@@ -1,0 +1,5 @@
+import { Lusitana } from 'next/font/google';
+
+export const lusitana = Lusitana({
+  weight: ['400'],
+});

--- a/dashboard/starter-example/app/ui/fonts/index.ts
+++ b/dashboard/starter-example/app/ui/fonts/index.ts
@@ -2,4 +2,5 @@ import { Lusitana } from 'next/font/google';
 
 export const lusitana = Lusitana({
   weight: ['400'],
+  subsets: ['latin'],
 });


### PR DESCRIPTION
When I tried to build the [Dashboard project](https://nextjs.org/learn/dashboard-app), the following error occurred.

```bash
Type error: Cannot find module '@/app/ui/fonts' or its corresponding type declarations.
```
