### PR TITLE
fix: remove incorrect labels in radio groups

### DIFF
--- a/dashboard/final-example/app/ui/invoices/create-form.tsx
+++ b/dashboard/final-example/app/ui/invoices/create-form.tsx
@@ -91,10 +91,10 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
         </div>
 
         {/* Invoice Status */}
-        <div>
-          <label htmlFor="status" className="mb-2 block text-sm font-medium">
+        <fieldset>
+          <legend className="mb-2 block text-sm font-medium">
             Set the invoice status
-          </label>
+          </legend>
           <div className="rounded-md border border-gray-200 bg-white px-[14px] py-3">
             <div className="flex gap-4">
               <div className="flex items-center">
@@ -140,7 +140,7 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
               ))}
             </div>
           ) : null}
-        </div>
+        </fieldset>
 
         {state.message ? (
           <div aria-live="polite" className="my-2 text-sm text-red-500">

--- a/dashboard/final-example/app/ui/invoices/edit-form.tsx
+++ b/dashboard/final-example/app/ui/invoices/edit-form.tsx
@@ -99,10 +99,10 @@ export default function EditInvoiceForm({
         </div>
 
         {/* Invoice Status */}
-        <div>
-          <label htmlFor="status" className="mb-2 block text-sm font-medium">
+        <fieldset>
+          <legend className="mb-2 block text-sm font-medium">
             Set the invoice status
-          </label>
+          </legend>
           <div className="rounded-md border border-gray-200 bg-white px-[14px] py-3">
             <div className="flex gap-4">
               <div className="flex items-center">
@@ -150,7 +150,7 @@ export default function EditInvoiceForm({
               ))}
             </div>
           ) : null}
-        </div>
+        </fieldset>
 
         {state.message ? (
           <div aria-live="polite" className="my-2 text-sm text-red-500">

--- a/dashboard/starter-example/app/ui/invoices/create-form.tsx
+++ b/dashboard/starter-example/app/ui/invoices/create-form.tsx
@@ -61,10 +61,10 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
         </div>
 
         {/* Invoice Status */}
-        <div>
-          <label htmlFor="status" className="mb-2 block text-sm font-medium">
+        <fieldset>
+          <legend className="mb-2 block text-sm font-medium">
             Set the invoice status
-          </label>
+          </legend>
           <div className="rounded-md border border-gray-200 bg-white px-[14px] py-3">
             <div className="flex gap-4">
               <div className="flex items-center">
@@ -99,7 +99,7 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
               </div>
             </div>
           </div>
-        </div>
+        </fieldset>
       </div>
       <div className="mt-6 flex justify-end gap-4">
         <Link

--- a/dashboard/starter-example/app/ui/invoices/edit-form.tsx
+++ b/dashboard/starter-example/app/ui/invoices/edit-form.tsx
@@ -68,10 +68,10 @@ export default function EditInvoiceForm({
         </div>
 
         {/* Invoice Status */}
-        <div>
-          <label htmlFor="status" className="mb-2 block text-sm font-medium">
+        <fieldset>
+          <legend className="mb-2 block text-sm font-medium">
             Set the invoice status
-          </label>
+          </legend>
           <div className="rounded-md border border-gray-200 bg-white px-[14px] py-3">
             <div className="flex gap-4">
               <div className="flex items-center">
@@ -108,7 +108,7 @@ export default function EditInvoiceForm({
               </div>
             </div>
           </div>
-        </div>
+        </fieldset>
       </div>
       <div className="mt-6 flex justify-end gap-4">
         <Link


### PR DESCRIPTION
This fixes an incorrect use of the `<label>` tag with a radio group. Moreover, the `htmlFor` attribute on the label pointed to an inexistent `id`.