### PR TITLE
Remove PPR flag, add `noStore` to `fetchInvoiceById`

### DIFF
--- a/dashboard/final-example/app/lib/data.ts
+++ b/dashboard/final-example/app/lib/data.ts
@@ -150,6 +150,7 @@ export async function fetchInvoicesPages(query: string) {
 }
 
 export async function fetchInvoiceById(id: string) {
+  noStore();
   try {
     const data = await sql<InvoiceForm>`
       SELECT

--- a/dashboard/final-example/next.config.js
+++ b/dashboard/final-example/next.config.js
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    ppr: true,
-  },
-};
+const nextConfig = {};
 
 module.exports = nextConfig;


### PR DESCRIPTION
Fixes: https://github.com/vercel/next-learn/issues/277

- Remove PPR flag as it doesn't work in production yet
- Add `noStore` to `fetchInvoiceById` to fetch fresh data when the user visits the edit invoice route. 
- Update code snippet in the chapter: https://github.com/vercel/front/pull/26672

I don't think we need to call `revalidatePath` to purge the client-side router cache, but if this issue happens again, we can explore using `revalidateTag` instead. 