### PR TITLE
Fix connection pooling with `seed.js` script

### DIFF
--- a/dashboard/final-example/scripts/seed.js
+++ b/dashboard/final-example/scripts/seed.js
@@ -1,4 +1,4 @@
-const { sql } = require('@vercel/postgres');
+const { db } = require('@vercel/postgres');
 const {
   invoices,
   customers,
@@ -7,11 +7,11 @@ const {
 } = require('../app/lib/placeholder-data.js');
 const bcrypt = require('bcrypt');
 
-async function seedUsers() {
+async function seedUsers(client) {
   try {
-    await sql`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`;
+    await client.sql`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`;
     // Create the "invoices" table if it doesn't exist
-    const createTable = await sql`
+    const createTable = await client.sql`
       CREATE TABLE IF NOT EXISTS users (
         id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
         name VARCHAR(255) NOT NULL,
@@ -26,7 +26,7 @@ async function seedUsers() {
     const insertedUsers = await Promise.all(
       users.map(async (user) => {
         const hashedPassword = await bcrypt.hash(user.password, 10);
-        return sql`
+        return client.sql`
         INSERT INTO users (id, name, email, password)
         VALUES (${user.id}, ${user.name}, ${user.email}, ${hashedPassword})
         ON CONFLICT (id) DO NOTHING;
@@ -46,12 +46,12 @@ async function seedUsers() {
   }
 }
 
-async function seedInvoices() {
+async function seedInvoices(client) {
   try {
-    await sql`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`;
+    await client.sql`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`;
 
     // Create the "invoices" table if it doesn't exist
-    const createTable = await sql`
+    const createTable = await client.sql`
     CREATE TABLE IF NOT EXISTS invoices (
     id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
     customer_id UUID NOT NULL,
@@ -66,7 +66,7 @@ async function seedInvoices() {
     // Insert data into the "invoices" table
     const insertedInvoices = await Promise.all(
       invoices.map(
-        (invoice) => sql`
+        (invoice) => client.sql`
         INSERT INTO invoices (customer_id, amount, status, date)
         VALUES (${invoice.customer_id}, ${invoice.amount}, ${invoice.status}, ${invoice.date})
         ON CONFLICT (id) DO NOTHING;
@@ -86,12 +86,12 @@ async function seedInvoices() {
   }
 }
 
-async function seedCustomers() {
+async function seedCustomers(client) {
   try {
-    await sql`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`;
+    await client.sql`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`;
 
     // Create the "customers" table if it doesn't exist
-    const createTable = await sql`
+    const createTable = await client.sql`
       CREATE TABLE IF NOT EXISTS customers (
         id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
         name VARCHAR(255) NOT NULL,
@@ -105,7 +105,7 @@ async function seedCustomers() {
     // Insert data into the "customers" table
     const insertedCustomers = await Promise.all(
       customers.map(
-        (customer) => sql`
+        (customer) => client.sql`
         INSERT INTO customers (id, name, email, image_url)
         VALUES (${customer.id}, ${customer.name}, ${customer.email}, ${customer.image_url})
         ON CONFLICT (id) DO NOTHING;
@@ -125,10 +125,10 @@ async function seedCustomers() {
   }
 }
 
-async function seedRevenue() {
+async function seedRevenue(client) {
   try {
     // Create the "revenue" table if it doesn't exist
-    const createTable = await sql`
+    const createTable = await client.sql`
       CREATE TABLE IF NOT EXISTS revenue (
         month VARCHAR(4) NOT NULL UNIQUE,
         revenue INT NOT NULL
@@ -140,7 +140,7 @@ async function seedRevenue() {
     // Insert data into the "revenue" table
     const insertedRevenue = await Promise.all(
       revenue.map(
-        (rev) => sql`
+        (rev) => client.sql`
         INSERT INTO revenue (month, revenue)
         VALUES (${rev.month}, ${rev.revenue})
         ON CONFLICT (month) DO NOTHING;
@@ -160,9 +160,20 @@ async function seedRevenue() {
   }
 }
 
-(async () => {
-  await seedUsers();
-  await seedCustomers();
-  await seedInvoices();
-  await seedRevenue();
-})();
+async function main() {
+  const client = await db.connect();
+
+  await seedUsers(client);
+  await seedCustomers(client);
+  await seedInvoices(client);
+  await seedRevenue(client);
+
+  await client.end();
+}
+
+main().catch((err) => {
+  console.error(
+    'An error occurred while attempting to seed the database:',
+    err,
+  );
+});

--- a/dashboard/starter-example/scripts/seed.js
+++ b/dashboard/starter-example/scripts/seed.js
@@ -1,4 +1,4 @@
-const { sql } = require('@vercel/postgres');
+const { db } = require('@vercel/postgres');
 const {
   invoices,
   customers,
@@ -7,11 +7,11 @@ const {
 } = require('../app/lib/placeholder-data.js');
 const bcrypt = require('bcrypt');
 
-async function seedUsers() {
+async function seedUsers(client) {
   try {
-    await sql`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`;
+    await client.sql`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`;
     // Create the "invoices" table if it doesn't exist
-    const createTable = await sql`
+    const createTable = await client.sql`
       CREATE TABLE IF NOT EXISTS users (
         id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
         name VARCHAR(255) NOT NULL,
@@ -26,7 +26,7 @@ async function seedUsers() {
     const insertedUsers = await Promise.all(
       users.map(async (user) => {
         const hashedPassword = await bcrypt.hash(user.password, 10);
-        return sql`
+        return client.sql`
         INSERT INTO users (id, name, email, password)
         VALUES (${user.id}, ${user.name}, ${user.email}, ${hashedPassword})
         ON CONFLICT (id) DO NOTHING;
@@ -46,12 +46,12 @@ async function seedUsers() {
   }
 }
 
-async function seedInvoices() {
+async function seedInvoices(client) {
   try {
-    await sql`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`;
+    await client.sql`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`;
 
     // Create the "invoices" table if it doesn't exist
-    const createTable = await sql`
+    const createTable = await client.sql`
     CREATE TABLE IF NOT EXISTS invoices (
     id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
     customer_id UUID NOT NULL,
@@ -66,7 +66,7 @@ async function seedInvoices() {
     // Insert data into the "invoices" table
     const insertedInvoices = await Promise.all(
       invoices.map(
-        (invoice) => sql`
+        (invoice) => client.sql`
         INSERT INTO invoices (customer_id, amount, status, date)
         VALUES (${invoice.customer_id}, ${invoice.amount}, ${invoice.status}, ${invoice.date})
         ON CONFLICT (id) DO NOTHING;
@@ -86,12 +86,12 @@ async function seedInvoices() {
   }
 }
 
-async function seedCustomers() {
+async function seedCustomers(client) {
   try {
-    await sql`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`;
+    await client.sql`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`;
 
     // Create the "customers" table if it doesn't exist
-    const createTable = await sql`
+    const createTable = await client.sql`
       CREATE TABLE IF NOT EXISTS customers (
         id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
         name VARCHAR(255) NOT NULL,
@@ -105,7 +105,7 @@ async function seedCustomers() {
     // Insert data into the "customers" table
     const insertedCustomers = await Promise.all(
       customers.map(
-        (customer) => sql`
+        (customer) => client.sql`
         INSERT INTO customers (id, name, email, image_url)
         VALUES (${customer.id}, ${customer.name}, ${customer.email}, ${customer.image_url})
         ON CONFLICT (id) DO NOTHING;
@@ -125,10 +125,10 @@ async function seedCustomers() {
   }
 }
 
-async function seedRevenue() {
+async function seedRevenue(client) {
   try {
     // Create the "revenue" table if it doesn't exist
-    const createTable = await sql`
+    const createTable = await client.sql`
       CREATE TABLE IF NOT EXISTS revenue (
         month VARCHAR(4) NOT NULL UNIQUE,
         revenue INT NOT NULL
@@ -140,7 +140,7 @@ async function seedRevenue() {
     // Insert data into the "revenue" table
     const insertedRevenue = await Promise.all(
       revenue.map(
-        (rev) => sql`
+        (rev) => client.sql`
         INSERT INTO revenue (month, revenue)
         VALUES (${rev.month}, ${rev.revenue})
         ON CONFLICT (month) DO NOTHING;
@@ -160,9 +160,20 @@ async function seedRevenue() {
   }
 }
 
-(async () => {
-  await seedUsers();
-  await seedCustomers();
-  await seedInvoices();
-  await seedRevenue();
-})();
+async function main() {
+  const client = await db.connect();
+
+  await seedUsers(client);
+  await seedCustomers(client);
+  await seedInvoices(client);
+  await seedRevenue(client);
+
+  await client.end();
+}
+
+main().catch((err) => {
+  console.error(
+    'An error occurred while attempting to seed the database:',
+    err,
+  );
+});


### PR DESCRIPTION
This PR fixes a pooling issue users were experiencing when running the `seed.js` script: https://github.com/vercel/next-learn/issues/306

- `sql` opens a new connection when called. 
- Since we used `Promise.all` to seed the database, the script was creating multiple connections in parallel. 
- A user found a fix using `for` loops instead of `Promise.all` ([here](https://github.com/vercel/next-learn/issues/306#issuecomment-1785766539)), however this doesn't prevent multiple connections from being opened - they are just opened sequentially. 

With this PR, we open a single connection with `db.connect()`, run our seeding scripts, then close the connection. 

```
async function main() {
  const client = await db.connect();

  await seedUsers(client);
  await seedCustomers(client);
  await seedInvoices(client);
  await seedRevenue(client);

  await client.end();
}

main().catch((err) => {
  console.error(
    'An error occurred while attempting to seed the database:',
    err,
  );
});
```
