### PR TITLE
Fix #243 Cannot find module '@/app/ui/fonts' error

### DIFF
--- a/dashboard/starter-example/app/ui/fonts.ts
+++ b/dashboard/starter-example/app/ui/fonts.ts
@@ -1,0 +1,8 @@
+import { Inter, Lusitana } from 'next/font/google';
+
+export const inter = Inter({ subsets: ['latin'] });
+
+export const lusitana = Lusitana({
+  weight: ['400', '700'],
+  subsets: ['latin'],
+});

--- a/dashboard/starter-example/app/ui/invoices/create-form.tsx
+++ b/dashboard/starter-example/app/ui/invoices/create-form.tsx
@@ -57,7 +57,6 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
               <CurrencyDollarIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
             </div>
           </div>
-          s
         </div>
 
         {/* Invoice Status */}


### PR DESCRIPTION
**Issue:** Resolves #243

**Changes Made:**
- Fixed the 'Cannot find module '@/app/ui/fonts' error.

**Description:**
I have resolved the issue by adding "fonts.ts" file under app/ui directory

```
import { Inter , Lusitana} from 'next/font/google';
export const inter = Inter({ 
  subsets: ['latin']
});
export const lusitana = Lusitana({
    weight: ['400', '700'],
   subsets: ['latin'],
});
```

**Test:**
I have tested the changes locally to ensure that the error is fixed.