### PR TITLE
Fix: typo in seed.js

### DIFF
--- a/dashboard/starter-example/scripts/seed.js
+++ b/dashboard/starter-example/scripts/seed.js
@@ -10,7 +10,7 @@ const bcrypt = require('bcrypt');
 async function seedUsers(client) {
   try {
     await client.sql`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`;
-    // Create the "invoices" table if it doesn't exist
+    // Create the "client" table if it doesn't exist
     const createTable = await client.sql`
       CREATE TABLE IF NOT EXISTS users (
         id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,


### PR DESCRIPTION
Corrected a typo in the seed.js script. 
The comment described creating the "invoices" table when the script is actually creating the "client" table.