### PR TITLE
Fix invoice amount validation (#409)

### DIFF
--- a/dashboard/final-example/app/ui/invoices/edit-form.tsx
+++ b/dashboard/final-example/app/ui/invoices/edit-form.tsx
@@ -75,6 +75,7 @@ export default function EditInvoiceForm({
                 id="amount"
                 name="amount"
                 type="number"
+                step="0.01"
                 defaultValue={invoice.amount}
                 placeholder="Enter USD amount"
                 className="peer block w-full rounded-md border border-gray-200 py-2 pl-10 text-sm outline-2 placeholder:text-gray-500"


### PR DESCRIPTION
Fixes: #409

Currently you cannot edit the decimal value of an invoice without a form validation error appearing.

Adding the appropriate step of one penny for both creating and editing invoices fixes the validation errors and provides expected behavior for inputting dollar amounts.