### PR TITLE
fix: throw new error in `fetchInvoiceById` catch block

### DIFF
--- a/dashboard/starter-example/app/lib/data.ts
+++ b/dashboard/starter-example/app/lib/data.ts
@@ -165,6 +165,7 @@ export async function fetchInvoiceById(id: string) {
     return invoice[0];
   } catch (error) {
     console.error('Database Error:', error);
+    throw new Error('Failed to fetch invoice.');
   }
 }
 


### PR DESCRIPTION
The steps in [Chapter 12, Step 3](https://nextjs.org/learn/dashboard-app/mutating-data#3-fetch-the-specific-invoice) of the dashboard tutorial result in a TypeScript error on the `invoice` prop of the edit invoice form. In the completed example there's an error thrown in the `catch` block, but in the starter project it is absent resulting in an error in the inferred function return type.

![CleanShot 2023-11-09 at 22 43 19@2x](https://github.com/vercel/next-learn/assets/1545970/dee6aec6-2aaa-4f2e-9ec3-bb370cbd023b)
