### PR TITLE
Fix: If currentPage is NaN throws error

### DIFF
--- a/dashboard/final-example/app/dashboard/invoices/page.tsx
+++ b/dashboard/final-example/app/dashboard/invoices/page.tsx
@@ -21,7 +21,11 @@ export default async function Page({
   };
 }) {
   const query = searchParams?.query || '';
-  const currentPage = Number(searchParams?.page) || 1;
+  let currentPage = Number(searchParams?.page) || 1;
+
+  if(Number.isNaN(currentPage)){
+    currentPage = 1;
+  }
 
   const totalPages = await fetchInvoicesPages(query);
 


### PR DESCRIPTION
In chapter 11 after completing the search implementation it throws an Error which is related to the query.
![Captura de Tela 2023-11-14 às 05 36 03](https://github.com/vercel/next-learn/assets/6100462/22b5b1b4-0b9d-4d51-9f30-bd8001f7626c)

When I was checking the data.ts noticed that we don't pass the currentPage at the first time so I did a NaN check to set if this is NaN to the first page
const offset = (currentPage - 1) * ITEMS_PER_PAGE;
