### PR TITLE
Improve Form Error Accessibility 

### DIFF
--- a/dashboard/final-example/app/ui/invoices/create-form.tsx
+++ b/dashboard/final-example/app/ui/invoices/create-form.tsx
@@ -44,17 +44,20 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
             <UserCircleIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500" />
           </div>
 
-          {state.errors?.customerId ? (
-            <div
-              id="customer-error"
-              aria-live="polite"
-              className="mt-2 text-sm text-red-500"
-            >
-              {state.errors.customerId.map((error: string) => (
-                <p key={error}>{error}</p>
-              ))}
-            </div>
-          ) : null}
+          <div
+            className="mt-2 text-sm text-red-500"
+            id="customer-error"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {state.errors?.customerId && (
+              <>
+                {state.errors.customerId.map((error: string) => (
+                  <p key={error}>{error}</p>
+                ))}
+              </>
+            )}
+          </div>
         </div>
 
         {/* Invoice Amount */}
@@ -77,17 +80,20 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
             </div>
           </div>
 
-          {state.errors?.amount ? (
-            <div
-              id="amount-error"
-              aria-live="polite"
-              className="mt-2 text-sm text-red-500"
-            >
-              {state.errors.amount.map((error: string) => (
-                <p key={error}>{error}</p>
-              ))}
-            </div>
-          ) : null}
+          <div
+            className="mt-2 text-sm text-red-500"
+            id="amount-error"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {state.errors?.amount && (
+              <>
+                {state.errors.amount.map((error: string) => (
+                  <p key={error}>{error}</p>
+                ))}
+              </>
+            )}
+          </div>
         </div>
 
         {/* Invoice Status */}
@@ -129,24 +135,29 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
               </div>
             </div>
           </div>
-          {state.errors?.status ? (
-            <div
-              aria-describedby="status-error"
-              aria-live="polite"
-              className="mt-2 text-sm text-red-500"
-            >
-              {state.errors.status.map((error: string) => (
-                <p key={error}>{error}</p>
-              ))}
-            </div>
-          ) : null}
+          <div
+            className="mt-2 text-sm text-red-500"
+            id="status-error"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {state.errors?.status && (
+              <>
+                {state.errors.status.map((error: string) => (
+                  <p key={error}>{error}</p>
+                ))}
+              </>
+            )}
+          </div>
         </fieldset>
 
-        {state.message ? (
-          <div aria-live="polite" className="my-2 text-sm text-red-500">
-            <p>{state.message}</p>
-          </div>
-        ) : null}
+        <div
+          className="mt-2 text-sm text-red-500"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {state.message ? <p>{state.message}</p> : null}
+        </div>
       </div>
       <div className="mt-6 flex justify-end gap-4">
         <Link

--- a/dashboard/final-example/app/ui/invoices/create-form.tsx
+++ b/dashboard/final-example/app/ui/invoices/create-form.tsx
@@ -44,19 +44,13 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
             <UserCircleIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500" />
           </div>
 
-          <div
-            className="mt-2 text-sm text-red-500"
-            id="customer-error"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {state.errors?.customerId && (
-              <>
-                {state.errors.customerId.map((error: string) => (
-                  <p key={error}>{error}</p>
-                ))}
-              </>
-            )}
+          <div id="customer-error" aria-live="polite" aria-atomic="true">
+            {state.errors?.customerId &&
+              state.errors.customerId.map((error: string) => (
+                <p className="mt-2 text-sm text-red-500" key={error}>
+                  {error}
+                </p>
+              ))}
           </div>
         </div>
 
@@ -80,19 +74,13 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
             </div>
           </div>
 
-          <div
-            className="mt-2 text-sm text-red-500"
-            id="amount-error"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {state.errors?.amount && (
-              <>
-                {state.errors.amount.map((error: string) => (
-                  <p key={error}>{error}</p>
-                ))}
-              </>
-            )}
+          <div id="amount-error" aria-live="polite" aria-atomic="true">
+            {state.errors?.amount &&
+              state.errors.amount.map((error: string) => (
+                <p className="mt-2 text-sm text-red-500" key={error}>
+                  {error}
+                </p>
+              ))}
           </div>
         </div>
 
@@ -135,28 +123,20 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
               </div>
             </div>
           </div>
-          <div
-            className="mt-2 text-sm text-red-500"
-            id="status-error"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {state.errors?.status && (
-              <>
-                {state.errors.status.map((error: string) => (
-                  <p key={error}>{error}</p>
-                ))}
-              </>
-            )}
+          <div id="status-error" aria-live="polite" aria-atomic="true">
+            {state.errors?.status &&
+              state.errors.status.map((error: string) => (
+                <p className="mt-2 text-sm text-red-500" key={error}>
+                  {error}
+                </p>
+              ))}
           </div>
         </fieldset>
 
-        <div
-          className="mt-2 text-sm text-red-500"
-          aria-live="polite"
-          aria-atomic="true"
-        >
-          {state.message ? <p>{state.message}</p> : null}
+        <div aria-live="polite" aria-atomic="true">
+          {state.message ? (
+            <p className="mt-2 text-sm text-red-500">{state.message}</p>
+          ) : null}
         </div>
       </div>
       <div className="mt-6 flex justify-end gap-4">

--- a/dashboard/final-example/app/ui/invoices/edit-form.tsx
+++ b/dashboard/final-example/app/ui/invoices/edit-form.tsx
@@ -51,19 +51,13 @@ export default function EditInvoiceForm({
             <UserCircleIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500" />
           </div>
 
-          <div
-            className="mt-2 text-sm text-red-500"
-            id="customer-error"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {state.errors?.customerId && (
-              <>
-                {state.errors.customerId.map((error: string) => (
-                  <p key={error}>{error}</p>
-                ))}
-              </>
-            )}
+          <div id="customer-error" aria-live="polite" aria-atomic="true">
+            {state.errors?.customerId &&
+              state.errors.customerId.map((error: string) => (
+                <p className="mt-2 text-sm text-red-500" key={error}>
+                  {error}
+                </p>
+              ))}
           </div>
         </div>
 
@@ -87,19 +81,13 @@ export default function EditInvoiceForm({
             </div>
           </div>
 
-          <div
-            className="mt-2 text-sm text-red-500"
-            id="amount-error"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {state.errors?.amount && (
-              <>
-                {state.errors.amount.map((error: string) => (
-                  <p key={error}>{error}</p>
-                ))}
-              </>
-            )}
+          <div id="amount-error" aria-live="polite" aria-atomic="true">
+            {state.errors?.amount &&
+              state.errors.amount.map((error: string) => (
+                <p className="mt-2 text-sm text-red-500" key={error}>
+                  {error}
+                </p>
+              ))}
           </div>
         </div>
 
@@ -144,28 +132,20 @@ export default function EditInvoiceForm({
               </div>
             </div>
           </div>
-          <div
-            className="mt-2 text-sm text-red-500"
-            id="status-error"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {state.errors?.status && (
-              <>
-                {state.errors.status.map((error: string) => (
-                  <p key={error}>{error}</p>
-                ))}
-              </>
-            )}
+          <div id="status-error" aria-live="polite" aria-atomic="true">
+            {state.errors?.status &&
+              state.errors.status.map((error: string) => (
+                <p className="mt-2 text-sm text-red-500" key={error}>
+                  {error}
+                </p>
+              ))}
           </div>
         </fieldset>
 
-        <div
-          aria-live="polite"
-          aria-atomic="true"
-          className="my-2 text-sm text-red-500"
-        >
-          {state.message ? <p>{state.message}</p> : null}
+        <div aria-live="polite" aria-atomic="true">
+          {state.message ? (
+            <p className="my-2 text-sm text-red-500">{state.message}</p>
+          ) : null}
         </div>
       </div>
       <div className="mt-6 flex justify-end gap-4">

--- a/dashboard/final-example/app/ui/invoices/edit-form.tsx
+++ b/dashboard/final-example/app/ui/invoices/edit-form.tsx
@@ -51,17 +51,20 @@ export default function EditInvoiceForm({
             <UserCircleIcon className="pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500" />
           </div>
 
-          {state.errors?.customerId ? (
-            <div
-              id="customer-error"
-              aria-live="polite"
-              className="mt-2 text-sm text-red-500"
-            >
-              {state.errors.customerId.map((error: string) => (
-                <p key={error}>{error}</p>
-              ))}
-            </div>
-          ) : null}
+          <div
+            className="mt-2 text-sm text-red-500"
+            id="customer-error"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {state.errors?.customerId && (
+              <>
+                {state.errors.customerId.map((error: string) => (
+                  <p key={error}>{error}</p>
+                ))}
+              </>
+            )}
+          </div>
         </div>
 
         {/* Invoice Amount */}
@@ -84,17 +87,20 @@ export default function EditInvoiceForm({
             </div>
           </div>
 
-          {state.errors?.amount ? (
-            <div
-              id="amount-error"
-              aria-live="polite"
-              className="mt-2 text-sm text-red-500"
-            >
-              {state.errors.amount.map((error: string) => (
-                <p key={error}>{error}</p>
-              ))}
-            </div>
-          ) : null}
+          <div
+            className="mt-2 text-sm text-red-500"
+            id="amount-error"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {state.errors?.amount && (
+              <>
+                {state.errors.amount.map((error: string) => (
+                  <p key={error}>{error}</p>
+                ))}
+              </>
+            )}
+          </div>
         </div>
 
         {/* Invoice Status */}
@@ -138,24 +144,29 @@ export default function EditInvoiceForm({
               </div>
             </div>
           </div>
-          {state.errors?.status ? (
-            <div
-              aria-describedby="status-error"
-              aria-live="polite"
-              className="mt-2 text-sm text-red-500"
-            >
-              {state.errors.status.map((error: string) => (
-                <p key={error}>{error}</p>
-              ))}
-            </div>
-          ) : null}
+          <div
+            className="mt-2 text-sm text-red-500"
+            id="status-error"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {state.errors?.status && (
+              <>
+                {state.errors.status.map((error: string) => (
+                  <p key={error}>{error}</p>
+                ))}
+              </>
+            )}
+          </div>
         </fieldset>
 
-        {state.message ? (
-          <div aria-live="polite" className="my-2 text-sm text-red-500">
-            <p>{state.message}</p>
-          </div>
-        ) : null}
+        <div
+          aria-live="polite"
+          aria-atomic="true"
+          className="my-2 text-sm text-red-500"
+        >
+          {state.message ? <p>{state.message}</p> : null}
+        </div>
       </div>
       <div className="mt-6 flex justify-end gap-4">
         <Link

--- a/dashboard/final-example/app/ui/login-form.tsx
+++ b/dashboard/final-example/app/ui/login-form.tsx
@@ -62,13 +62,15 @@ export default function LoginForm() {
           </div>
         </div>
         <LoginButton />
-        <div className="flex h-8 items-end space-x-1">
+        <div
+          className="flex h-8 items-end space-x-1"
+          aria-live="polite"
+          aria-atomic="true"
+        >
           {state === 'CredentialsSignin' && (
             <>
               <ExclamationCircleIcon className="h-5 w-5 text-red-500" />
-              <p aria-live="polite" className="text-sm text-red-500">
-                Invalid credentials
-              </p>
+              <p className="text-sm text-red-500">Invalid credentials</p>
             </>
           )}
         </div>


### PR DESCRIPTION
The `aria-live` region for form errors needs to be present in the DOM to allow screen readers to monitor changes. This PR updates the structure, and moves the label outside the conditional. 

More context: https://github.com/vercel/next-learn/issues/418
See also: https://dev.to/abbeyperini/live-regions-in-react-4dmd

PR to update the chapter: https://github.com/vercel/front/pull/27101