### PR TITLE
Simplify middleware matcher

### DIFF
--- a/dashboard/final-example/middleware.ts
+++ b/dashboard/final-example/middleware.ts
@@ -5,5 +5,5 @@ export default NextAuth(authConfig).auth;
 
 export const config = {
   // https://nextjs.org/docs/app/building-your-application/routing/middleware#matcher
-  matcher: ['/((?!api|_next/static|_next/image|.*\\.png$|.*\\.ico$).*)'],
+  matcher: ['/login', '/dashboard/:path*'],
 };

--- a/dashboard/final-example/middleware.ts
+++ b/dashboard/final-example/middleware.ts
@@ -5,5 +5,5 @@ export default NextAuth(authConfig).auth;
 
 export const config = {
   // https://nextjs.org/docs/app/building-your-application/routing/middleware#matcher
-  matcher: ['/((?!api|_next/static|_next/image|.*\\.png$).*)'],
+  matcher: ['/((?!api|_next/static|_next/image|.*\\.png$|.*\\.ico$).*)'],
 };


### PR DESCRIPTION
We want to redirect the user to `/login` or `/dashboard` depending on whether they are logged in or not. 

Desired behavior: 

- If the user is **logged in**  and lands on the `/dashboard/*`, keep the user on the dashboard route. 
- If the user is **logged in**  and lands on the `/login` route, we want to redirect them to `/dashboard`
- If the user is **not logged in** and lands on the `/dashboard` routes, we want to redirect them to `/login`
- Images and favicon should work in production 

With the current solution, we are saying middleware should **run on everything** but ignore these paths: 

```
export const config = {
  matcher: [
    '/((?!api|_next/static|_next/image|favicon.ico).*)',
  ],
}
```

This caused images to break in production when logged in so we updated it by adding: `.*\\.png$`.

But this approach is not very scalable, and can be error-prone. E.g. What if users added `jpg`? Then we'd also have to say _don't run on jpg files_. 

Instead, what if specify **only** the routes middleware should run on: `/login` or `/dashboard/*` - and exclude everything else. 

Since we have this redirect logic in `auth.config.js`: 

```
authorized({ auth, request: { nextUrl } }) {
      const isLoggedIn = !!auth?.user;
      const isOnDashboard = nextUrl.pathname.startsWith('/dashboard');
      if (isOnDashboard) {
        if (isLoggedIn) return true;
        return false; // Redirect unauthenticated users to login page
      } else if (isLoggedIn) {
        return Response.redirect(new URL('/dashboard', nextUrl));
      }
      return true;
    },
```

We can **specify only the paths** middleware should run: 

```
export const config = {
  matcher: ['/login', '/dashboard/:path*'],
};
```

And let `NextAuth.js` handle the redirect logic. This achieves the same result, and images are not broken in production. 