### PR TITLE
chore: bump `next-auth`

### DIFF
--- a/dashboard/final-example/app/lib/actions.ts
+++ b/dashboard/final-example/app/lib/actions.ts
@@ -5,6 +5,7 @@ import { sql } from '@vercel/postgres';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { signIn } from '@/auth';
+import { AuthError } from 'next-auth';
 
 const FormSchema = z.object({
   id: z.string(),
@@ -124,10 +125,15 @@ export async function authenticate(
   formData: FormData,
 ) {
   try {
-    await signIn('credentials', Object.fromEntries(formData));
+    await signIn('credentials', formData);
   } catch (error) {
-    if ((error as Error).message.includes('CredentialsSignin')) {
-      return 'CredentialsSignin';
+    if (error instanceof AuthError) {
+      switch (error.type) {
+        case 'CredentialsSignin':
+          return 'Invalid credentials.';
+        default:
+          return 'Something went wrong. Check the logs for more information.';
+      }
     }
     throw error;
   }

--- a/dashboard/final-example/app/lib/actions.ts
+++ b/dashboard/final-example/app/lib/actions.ts
@@ -132,7 +132,7 @@ export async function authenticate(
         case 'CredentialsSignin':
           return 'Invalid credentials.';
         default:
-          return 'Something went wrong. Check the logs for more information.';
+          return 'Something went wrong.';
       }
     }
     throw error;

--- a/dashboard/final-example/app/ui/login-form.tsx
+++ b/dashboard/final-example/app/ui/login-form.tsx
@@ -12,7 +12,7 @@ import { Button } from './button';
 import { useFormState, useFormStatus } from 'react-dom';
 
 export default function LoginForm() {
-  const [state, dispatch] = useFormState(authenticate, undefined);
+  const [errorMessage, dispatch] = useFormState(authenticate, undefined);
 
   return (
     <form action={dispatch} className="space-y-3">
@@ -67,10 +67,10 @@ export default function LoginForm() {
           aria-live="polite"
           aria-atomic="true"
         >
-          {state === 'CredentialsSignin' && (
+          {errorMessage && (
             <>
               <ExclamationCircleIcon className="h-5 w-5 text-red-500" />
-              <p className="text-sm text-red-500">Invalid credentials</p>
+              <p className="text-sm text-red-500">{errorMessage}</p>
             </>
           )}
         </div>

--- a/dashboard/final-example/package.json
+++ b/dashboard/final-example/package.json
@@ -18,7 +18,7 @@
     "bcrypt": "^5.1.1",
     "clsx": "^2.0.0",
     "next": "^14.0.2",
-    "next-auth": "^5.0.0-beta.3",
+    "next-auth": "^5.0.0-beta.4",
     "postcss": "8.4.31",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
This PR bumps NextAuth.js to the latest version.


The main noticeable change is cleaner error handling: Whenever a NextAuth.js-induced error happens in a Server Action, we now throw an [`AuthError` instance](https://authjs.dev/reference/core/errors#autherror) that makes error handling a bit easier.

In addition, this new release includes bug fixes. See the release notes: https://github.com/nextauthjs/next-auth/releases/tag/next-auth%405.0.0-beta.4

[Slack thread](https://vercel.slack.com/archives/C05KP92R51B/p1701179666546759)