### PR TITLE
fix: add divide class instead of dynamic border rendering

### DIFF
--- a/dashboard/final-example/app/ui/dashboard/latest-invoices.tsx
+++ b/dashboard/final-example/app/ui/dashboard/latest-invoices.tsx
@@ -1,5 +1,4 @@
 import { ArrowPathIcon } from '@heroicons/react/24/outline';
-import clsx from 'clsx';
 import Image from 'next/image';
 import { lusitana } from '@/app/ui/fonts';
 import { fetchLatestInvoices } from '@/app/lib/data';
@@ -12,18 +11,12 @@ export default async function LatestInvoices() {
         Latest Invoices
       </h2>
       <div className="flex grow flex-col justify-between rounded-xl bg-gray-50 p-4">
-        <div className="bg-white px-6">
-          {latestInvoices.map((invoice, i) => {
+        <div className="bg-white px-6 divide-y">
+          {latestInvoices.map((invoice) => {
             return (
               <div
                 key={invoice.id}
-                className={clsx(
-                  'flex flex-row items-center justify-between py-4',
-                  {
-                    'border-t': i !== 0,
-                  },
-                )}
-              >
+                className="flex flex-row items-center justify-between py-4">
                 <div className="flex items-center">
                   <Image
                     src={invoice.image_url}

--- a/dashboard/starter-example/app/ui/dashboard/latest-invoices.tsx
+++ b/dashboard/starter-example/app/ui/dashboard/latest-invoices.tsx
@@ -1,5 +1,4 @@
 import { ArrowPathIcon } from '@heroicons/react/24/outline';
-import clsx from 'clsx';
 import Image from 'next/image';
 import { lusitana } from '@/app/ui/fonts';
 import { LatestInvoice } from '@/app/lib/definitions';
@@ -16,18 +15,12 @@ export default async function LatestInvoices({
       <div className="flex grow flex-col justify-between rounded-xl bg-gray-50 p-4">
         {/* NOTE: comment in this code when you get to this point in the course */}
 
-        {/* <div className="bg-white px-6">
-          {latestInvoices.map((invoice, i) => {
+        {/* <div className="bg-white px-6 divide-y">
+          {latestInvoices.map((invoice) => {
             return (
               <div
                 key={invoice.id}
-                className={clsx(
-                  'flex flex-row items-center justify-between py-4',
-                  {
-                    'border-t': i !== 0,
-                  },
-                )}
-              >
+                className="flex flex-row items-center justify-between py-4">
                 <div className="flex items-center">
                   <Image
                     src={invoice.image_url}


### PR DESCRIPTION
Hi, I noticed, that there is a top border dynamically created, which is the explicit use case for the tailwind divide class. In praxis you would just add this tailwind class instead of doing it by yourself. Hope it helps!