### PR TITLE
Remove unused getUser

### DIFF
--- a/dashboard/final-example/app/lib/data.ts
+++ b/dashboard/final-example/app/lib/data.ts
@@ -226,13 +226,3 @@ export async function fetchFilteredCustomers(query: string) {
     throw new Error('Failed to fetch customer table.');
   }
 }
-
-export async function getUser(email: string) {
-  try {
-    const user = await sql`SELECT * FROM users WHERE email=${email}`;
-    return user.rows[0] as User;
-  } catch (error) {
-    console.error('Failed to fetch user:', error);
-    throw new Error('Failed to fetch user.');
-  }
-}

--- a/dashboard/final-example/app/lib/data.ts
+++ b/dashboard/final-example/app/lib/data.ts
@@ -5,7 +5,6 @@ import {
   InvoiceForm,
   InvoicesTable,
   LatestInvoiceRaw,
-  User,
   Revenue,
 } from './definitions';
 import { formatCurrency } from './utils';

--- a/dashboard/starter-example/app/lib/data.ts
+++ b/dashboard/starter-example/app/lib/data.ts
@@ -5,7 +5,6 @@ import {
   InvoiceForm,
   InvoicesTable,
   LatestInvoiceRaw,
-  User,
   Revenue,
 } from './definitions';
 import { formatCurrency } from './utils';

--- a/dashboard/starter-example/app/lib/data.ts
+++ b/dashboard/starter-example/app/lib/data.ts
@@ -219,13 +219,3 @@ export async function fetchFilteredCustomers(query: string) {
     throw new Error('Failed to fetch customer table.');
   }
 }
-
-export async function getUser(email: string) {
-  try {
-    const user = await sql`SELECT * FROM users WHERE email=${email}`;
-    return user.rows[0] as User;
-  } catch (error) {
-    console.error('Failed to fetch user:', error);
-    throw new Error('Failed to fetch user.');
-  }
-}


### PR DESCRIPTION
`getUser` implementation got moved to `@app/lib/data`:
- #212 

However, during the update of `auth.ts`, somehow `getUser` got decided to retained in `auth.ts` (which might be a result of a git conflict or intended to bundle seperatly)
- #219

and the one that moved in `@app/lib/data` was not removed.

1. `getUser` in the `@app/lib/data` is no longer in use.
2. Chapter 15 describes upon the one in `auth.ts`

Therefore, shouldn't we remove the unused one left in  `@app/lib/data` unless it was unintentional ?
or we could consider removing the one in `auth.ts` with updating Chapter 15 mdx (don't forget to update type assertion to generic.)

In any case, one of them should be removed.

Thank you for the amazing course.