### PR TITLE
Added missing fonts file in starter-example

### DIFF
--- a/dashboard/starter-example/app/ui/fonts.tsx
+++ b/dashboard/starter-example/app/ui/fonts.tsx
@@ -1,0 +1,8 @@
+import { Inter, Lusitana } from 'next/font/google';
+
+export const inter = Inter({ subsets: ['latin'] });
+
+export const lusitana = Lusitana({
+  weight: ['400', '700'],
+  subsets: ['latin'],
+});


### PR DESCRIPTION
When following the tutorial, and first time starting the build, it fails with

> Cannot find module '@/app/ui/fonts' or its corresponding type declarations.ts(2307)

I copy / pasted the file from the final-example, to fix it.

If you don't want to have this code in the starter, then you should adopt the **chapter one** part, where it tells you to build the project, which of course will fail with all the imports of this file which is missing...

https://nextjs.org/learn/dashboard-app/getting-started

> Followed by npm run dev to start the development server.

Honestly, I would not have a starter where things are already broken. Not sure why this file is that important and I saw, that it might get added later in the chapters... I would fix one or the other to have a running build also on the starter.