### PR TITLE
Update classname props to svg props in LinkIcon in nav-links.tsx

### DIFF
--- a/dashboard/final-example/app/ui/dashboard/nav-links.tsx
+++ b/dashboard/final-example/app/ui/dashboard/nav-links.tsx
@@ -39,7 +39,7 @@ export default function NavLinks() {
               },
             )}
           >
-            <LinkIcon className="w-6" />
+               <LinkIcon width="24" height="24" />
             <p className="hidden md:block">{link.name}</p>
           </Link>
         );


### PR DESCRIPTION
Thee @heroicons/react library exports SVG icons as React components. These components accept all standard SVG props. However, the className prop passed into the component wasn't working as expected because SVGs have their own set of CSS properties.

Instead of using className, using the width and height props directly on the LinkIcon component works perfectly