### PR TITLE
Fix pagination ellipsis display bug

### DIFF
--- a/dashboard/final-example/app/ui/invoices/pagination.tsx
+++ b/dashboard/final-example/app/ui/invoices/pagination.tsx
@@ -38,7 +38,7 @@ export default function Pagination({ totalPages }: { totalPages: number }) {
 
           return (
             <PaginationNumber
-              key={page}
+              key={page === '...' ? `ellipsis-${index}` : page}
               href={createPageURL(page)}
               page={page}
               position={position}

--- a/dashboard/starter-example/app/ui/invoices/pagination.tsx
+++ b/dashboard/starter-example/app/ui/invoices/pagination.tsx
@@ -32,7 +32,7 @@ export default function Pagination({ totalPages }: { totalPages: number }) {
 
             return (
               <PaginationNumber
-                key={page}
+                key={page === '...' ? `ellipsis-${index}` : page}
                 href={createPageURL(page)}
                 page={page}
                 position={position}


### PR DESCRIPTION
The `page` is set as the key for `PaginationNumber`, but when two ellipses are displayed, the key will be duplicated and the display is corrupted. 
Fix so that if the `page`  is a `...` (ellipsis), the `ellipsis-`  prefix and `index` combination is used as the key.

![output](https://github.com/vercel/next-learn/assets/47820497/8273c421-855b-4ed3-b417-a0bf7b0d6aba)
