### PR TITLE
Fix: make UI skeleton more similar to the actual component

### DIFF
--- a/dashboard/final-example/app/ui/skeletons.tsx
+++ b/dashboard/final-example/app/ui/skeletons.tsx
@@ -72,10 +72,10 @@ export function LatestInvoicesSkeleton() {
           <InvoiceSkeleton />
           <InvoiceSkeleton />
           <InvoiceSkeleton />
-          <div className="flex items-center pb-2 pt-6">
-            <div className="h-5 w-5 rounded-full bg-gray-200" />
-            <div className="ml-2 h-4 w-20 rounded-md bg-gray-200" />
-          </div>
+        </div>
+        <div className="flex items-center pb-2 pt-6">
+          <div className="h-5 w-5 rounded-full bg-gray-200" />
+          <div className="ml-2 h-4 w-20 rounded-md bg-gray-200" />
         </div>
       </div>
     </div>

--- a/dashboard/starter-example/app/ui/skeletons.tsx
+++ b/dashboard/starter-example/app/ui/skeletons.tsx
@@ -72,10 +72,10 @@ export function LatestInvoicesSkeleton() {
           <InvoiceSkeleton />
           <InvoiceSkeleton />
           <InvoiceSkeleton />
-          <div className="flex items-center pb-2 pt-6">
-            <div className="h-5 w-5 rounded-full bg-gray-200" />
-            <div className="ml-2 h-4 w-20 rounded-md bg-gray-200" />
-          </div>
+        </div>
+        <div className="flex items-center pb-2 pt-6">
+          <div className="h-5 w-5 rounded-full bg-gray-200" />
+          <div className="ml-2 h-4 w-20 rounded-md bg-gray-200" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
All this fix does is moving closing `</div>` tag in the `LatestInvoicesSkeleton` component so that the skeleton looks as close as the actual `LatestInvoices` component

Skeleton before:

![before](https://github.com/vercel/next-learn/assets/33166095/07c18e8f-998d-454a-9e6b-b5d89e4f5720)

Skeleton after:

![after](https://github.com/vercel/next-learn/assets/33166095/a4e9cac3-0576-4951-810a-261ea231e4d0)

Component:

![component](https://github.com/vercel/next-learn/assets/33166095/014f7a83-1267-48b1-ba86-865ecad9871f)
