### PR TITLE
Apply a concrete type to the props of the InvoiceStatus component

### DIFF
--- a/dashboard/starter-example/app/ui/invoices/status.tsx
+++ b/dashboard/starter-example/app/ui/invoices/status.tsx
@@ -1,7 +1,8 @@
 import { CheckIcon, ClockIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
+import { InvoicesTable } from '@/app/lib/definitions';
 
-export default function InvoiceStatus({ status }: { status: string }) {
+export default function InvoiceStatus({ status }: { status: InvoicesTable['status'] }) {
   return (
     <span
       className={clsx(


### PR DESCRIPTION
Hello

I was studying through next learn and came across the InvoiceStatus component.

It takes a status prop and I saw that it is defined as a string type.
I'm using the status prop to handle conditional statements, but I think it would be better if it was declared as a concrete type.
