### PR TITLE
Add index to Pagination key for uniqueness

### DIFF
--- a/dashboard/final-example/app/ui/invoices/pagination.tsx
+++ b/dashboard/final-example/app/ui/invoices/pagination.tsx
@@ -38,7 +38,7 @@ export default function Pagination({ totalPages }: { totalPages: number }) {
 
           return (
             <PaginationNumber
-              key={page}
+              key={`${page}-${index}`}
               href={createPageURL(page)}
               page={page}
               position={position}


### PR DESCRIPTION
Using only the page as a key does not preserve uniqueness across updates. This caused, for example, an ellipsis to appear before the pagination elements when navigating from a page in the middle of the results back to the first page.