### PR TITLE
Remove Environment Variable AUTH_URL 

### DIFF
--- a/dashboard/starter-example/.env.example
+++ b/dashboard/starter-example/.env.example
@@ -10,4 +10,3 @@ POSTGRES_DATABASE=
 
 # `openssl rand -base64 32`
 AUTH_SECRET=
-AUTH_URL=http://localhost:3000/api/auth


### PR DESCRIPTION
Upon completing Chapter 15 I received this warning.
`[auth][warn][env-url-basepath-redundant] Read more: https://warnings.authjs.dev#env-url-basepath-redundant`

After investigating a little I found that Auth.js version 5 infers [AUTH_URL](https://authjs.dev/getting-started/deployment#auth_url) automatically based on request headers and has defined this environment variable as mostly unnecessary. 

> **AUTH_URL**
>This environment variable is mostly unnecessary with v5 as the host is inferred from the request headers. However, if you are >using a different base path, you can set this environment variable as well. For example, `AUTH_URL=http://localhost:3000/web/>auth` or `AUTH_URL=https://company.com/app1/auth`

Getting rid of this line from my .env file removes the warning and everything still works like normal when logging in/out.

I'm hoping that removing it from the example file will prevent others from going through the same confusion I did with this problem. 