### PR TITLE
Add type='submit' prop to logout button form

### DIFF
--- a/dashboard/final-example/app/ui/dashboard/sidenav.tsx
+++ b/dashboard/final-example/app/ui/dashboard/sidenav.tsx
@@ -24,7 +24,7 @@ export default function SideNav() {
             await signOut();
           }}
         >
-          <button className="flex h-[48px] w-full grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3">
+          <button type="submit" className="flex h-[48px] w-full grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3">
             <PowerIcon className="w-6" />
             <div className="hidden md:block">Sign Out</div>
           </button>

--- a/dashboard/starter-example/app/ui/dashboard/sidenav.tsx
+++ b/dashboard/starter-example/app/ui/dashboard/sidenav.tsx
@@ -18,7 +18,7 @@ export default function SideNav() {
         <NavLinks />
         <div className="hidden h-auto w-full grow rounded-md bg-gray-50 md:block"></div>
         <form>
-          <button className="flex h-[48px] w-full grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3">
+          <button type="submit" className="flex h-[48px] w-full grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3">
             <PowerIcon className="w-6" />
             <div className="hidden md:block">Sign Out</div>
           </button>


### PR DESCRIPTION
### Description
This PR adds the `type='submit'` attribute to the logout button form. Currently, the button lacks this attribute, which specifies the type of the button and ensures proper functionality when users attempt to submit the form for logging out.

### Changes Made
- Added `type='submit'` prop to the logout button form.

### Reason for Changes
By adding `type='submit'`, we ensure that the logout button behaves consistently across browsers and adheres to best practices for form submission.

Please review and merge this PR at your earliest convenience. Thank you!