### PR TITLE
Fix: Add missing required field

### DIFF
--- a/dashboard/final-example/app/ui/invoices/create-form.tsx
+++ b/dashboard/final-example/app/ui/invoices/create-form.tsx
@@ -93,6 +93,7 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
             <div className="flex gap-4">
               <div className="flex items-center">
                 <input
+                  required
                   id="pending"
                   name="status"
                   type="radio"
@@ -108,6 +109,7 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
               </div>
               <div className="flex items-center">
                 <input
+                  required
                   id="paid"
                   name="status"
                   type="radio"

--- a/dashboard/starter-example/app/ui/invoices/create-form.tsx
+++ b/dashboard/starter-example/app/ui/invoices/create-form.tsx
@@ -66,6 +66,7 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
             <div className="flex gap-4">
               <div className="flex items-center">
                 <input
+                  required
                   id="pending"
                   name="status"
                   type="radio"
@@ -81,6 +82,7 @@ export default function Form({ customers }: { customers: CustomerField[] }) {
               </div>
               <div className="flex items-center">
                 <input
+                  required
                   id="paid"
                   name="status"
                   type="radio"


### PR DESCRIPTION
While reading through Chapter 12 of the [Next.js tutorial](https://nextjs.org/learn/dashboard-app/mutating-data), I noticed that based on the TypeScript interface definition, we shouldn't allow the user to submit the form without selecting the invoice status.

```ts
export type Invoice = {
  id: string; // Will be created on the database
  customer_id: string;
  amount: number; // Stored in cents
  status: 'pending' | 'paid';
  date: string;
};
```