### PR TITLE
Fix: Upgrade next-auth to fix auth example

### DIFF
--- a/dashboard/final-example/package.json
+++ b/dashboard/final-example/package.json
@@ -13,7 +13,7 @@
     "bcrypt": "^5.1.1",
     "clsx": "^2.1.1",
     "next": "15.0.0-canary.56",
-    "next-auth": "5.0.0-beta.19",
+    "next-auth": "5.0.0-beta.20",
     "postcss": "8.4.38",
     "react": "19.0.0-rc-f38c22b244-20240704",
     "react-dom": "19.0.0-rc-f38c22b244-20240704",

--- a/dashboard/final-example/pnpm-lock.yaml
+++ b/dashboard/final-example/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: 15.0.0-canary.56
     version: 15.0.0-canary.56(react-dom@19.0.0-rc-f38c22b244-20240704)(react@19.0.0-rc-f38c22b244-20240704)
   next-auth:
-    specifier: 5.0.0-beta.19
-    version: 5.0.0-beta.19(next@15.0.0-canary.56)(react@19.0.0-rc-f38c22b244-20240704)
+    specifier: 5.0.0-beta.20
+    version: 5.0.0-beta.20(next@15.0.0-canary.56)(react@19.0.0-rc-f38c22b244-20240704)
   postcss:
     specifier: 8.4.38
     version: 8.4.38
@@ -72,8 +72,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /@auth/core@0.32.0:
-    resolution: {integrity: sha512-3+ssTScBd+1fd0/fscAyQN1tSygXzuhysuVVzB942ggU4mdfiTbv36P0ccVnExKWYJKvu3E2r3/zxXCCAmTOrg==}
+  /@auth/core@0.34.2:
+    resolution: {integrity: sha512-KywHKRgLiF3l7PLyL73fjLSIBe1YNcA6sMeew4yMP6cfCWGXZrkkXd32AjRi1hlJ9nvovUBGZHvbn+LijO6ZeQ==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
@@ -1176,12 +1176,12 @@ packages:
     hasBin: true
     dev: false
 
-  /next-auth@5.0.0-beta.19(next@15.0.0-canary.56)(react@19.0.0-rc-f38c22b244-20240704):
-    resolution: {integrity: sha512-YHu1igcAxZPh8ZB7GIM93dqgY6gcAzq66FOhQFheAdOx1raxNcApt05nNyNCSB6NegSiyJ4XOPsaNow4pfDmsg==}
+  /next-auth@5.0.0-beta.20(next@15.0.0-canary.56)(react@19.0.0-rc-f38c22b244-20240704):
+    resolution: {integrity: sha512-+48SjV9k9AtUU3JbEIa4PXNjKIewfFjVGL7Xs2RKkuQ5QqegDNIQiIG8sLk6/qo7RTScQYIGKgeQ5IuQRtrTQg==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
-      next: ^14 || ^15.0.0-0
+      next: ^14.0.0-0 || ^15.0.0-0
       nodemailer: ^6.6.5
       react: ^18.2.0 || ^19.0.0-0
     peerDependenciesMeta:
@@ -1192,7 +1192,7 @@ packages:
       nodemailer:
         optional: true
     dependencies:
-      '@auth/core': 0.32.0
+      '@auth/core': 0.34.2
       next: 15.0.0-canary.56(react-dom@19.0.0-rc-f38c22b244-20240704)(react@19.0.0-rc-f38c22b244-20240704)
       react: 19.0.0-rc-f38c22b244-20240704
     dev: false

--- a/dashboard/starter-example/package.json
+++ b/dashboard/starter-example/package.json
@@ -13,7 +13,7 @@
     "bcrypt": "^5.1.1",
     "clsx": "^2.1.1",
     "next": "15.0.0-canary.56",
-    "next-auth": "5.0.0-beta.19",
+    "next-auth": "5.0.0-beta.20",
     "postcss": "8.4.38",
     "react": "19.0.0-rc-f38c22b244-20240704",
     "react-dom": "19.0.0-rc-f38c22b244-20240704",

--- a/dashboard/starter-example/pnpm-lock.yaml
+++ b/dashboard/starter-example/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: 15.0.0-canary.56
     version: 15.0.0-canary.56(react-dom@19.0.0-rc-f38c22b244-20240704)(react@19.0.0-rc-f38c22b244-20240704)
   next-auth:
-    specifier: 5.0.0-beta.19
-    version: 5.0.0-beta.19(next@15.0.0-canary.56)(react@19.0.0-rc-f38c22b244-20240704)
+    specifier: 5.0.0-beta.20
+    version: 5.0.0-beta.20(next@15.0.0-canary.56)(react@19.0.0-rc-f38c22b244-20240704)
   postcss:
     specifier: 8.4.38
     version: 8.4.38
@@ -72,8 +72,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /@auth/core@0.32.0:
-    resolution: {integrity: sha512-3+ssTScBd+1fd0/fscAyQN1tSygXzuhysuVVzB942ggU4mdfiTbv36P0ccVnExKWYJKvu3E2r3/zxXCCAmTOrg==}
+  /@auth/core@0.34.2:
+    resolution: {integrity: sha512-KywHKRgLiF3l7PLyL73fjLSIBe1YNcA6sMeew4yMP6cfCWGXZrkkXd32AjRi1hlJ9nvovUBGZHvbn+LijO6ZeQ==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
@@ -1174,12 +1174,12 @@ packages:
     hasBin: true
     dev: false
 
-  /next-auth@5.0.0-beta.19(next@15.0.0-canary.56)(react@19.0.0-rc-f38c22b244-20240704):
-    resolution: {integrity: sha512-YHu1igcAxZPh8ZB7GIM93dqgY6gcAzq66FOhQFheAdOx1raxNcApt05nNyNCSB6NegSiyJ4XOPsaNow4pfDmsg==}
+  /next-auth@5.0.0-beta.20(next@15.0.0-canary.56)(react@19.0.0-rc-f38c22b244-20240704):
+    resolution: {integrity: sha512-+48SjV9k9AtUU3JbEIa4PXNjKIewfFjVGL7Xs2RKkuQ5QqegDNIQiIG8sLk6/qo7RTScQYIGKgeQ5IuQRtrTQg==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
-      next: ^14 || ^15.0.0-0
+      next: ^14.0.0-0 || ^15.0.0-0
       nodemailer: ^6.6.5
       react: ^18.2.0 || ^19.0.0-0
     peerDependenciesMeta:
@@ -1190,7 +1190,7 @@ packages:
       nodemailer:
         optional: true
     dependencies:
-      '@auth/core': 0.32.0
+      '@auth/core': 0.34.2
       next: 15.0.0-canary.56(react-dom@19.0.0-rc-f38c22b244-20240704)(react@19.0.0-rc-f38c22b244-20240704)
       react: 19.0.0-rc-f38c22b244-20240704
     dev: false


### PR DESCRIPTION
# SYMPTOM

There is a behavior mismatch when I follow the [Chapter 15 Adding Authentication - Updating the login form](https://nextjs.org/learn/dashboard-app/adding-authentication#updating-the-login-form)

For the function `authenticate` of `/app/lib/actions.ts`:
```js
export async function authenticate(prevState: string | undefined, formData: FormData) {
  try {
    await signIn('credentials', formData);
  } catch (error) {
    if (error instanceof AuthError) {
      switch (error.type) {
        case 'CredentialsSignin':    // <-- Should Go Into Here
          return 'Invalid credentials.';
        default:    // <-- But Go Into Here
          return 'Something went wrong.';
      }
    }
    throw error;
  }
}
```
When I input the right email and wrong password, it should throw the `CredentialsSignin` error, but acutally it throws `CallbackRouteError`. The consequence is, the UI shows error message "Something went wrong." instead of "Invalid credentials.".

Reference:
* Same issue is also reported at: https://github.com/vercel/next-learn/issues/734

# CAUSE

The cause is the package `next-auth@5.0.0-beta.19`.

Many `next-auth` users report same issue that, they found `next-auth` throws `CallbackRouteError` instead of `CredentialsSignin`. The issue is narrowed down to `next-auth@5.0.0-beta.19`, there is a code change breaks error type contract.

Reference:
* `next-auth` users report the error type issue: https://github.com/nextauthjs/next-auth/issues/11074
* The code change which introduces the type issue into `next-auth@5.0.0-beta.19`: https://github.com/nextauthjs/next-auth/pull/11050

# FIX

The `next-auth` team's noticed this issue and fixed it in new version, `next-auth@5.0.0-beta.20`. So we can upgrade to `next-auth@5.0.0-beta.20` to fix the authentication behavior.

Reference:
* The `next-auth` pull request to fix the error type issue: https://github.com/nextauthjs/next-auth/pull/11469
