### PR TITLE
Fix ESLint Error defined but never used in Chapter 14

### DIFF
--- a/dashboard/starter-example/app/ui/customers/table.tsx
+++ b/dashboard/starter-example/app/ui/customers/table.tsx
@@ -1,10 +1,7 @@
 import Image from 'next/image';
 import { lusitana } from '@/app/ui/fonts';
 import Search from '@/app/ui/search';
-import {
-  CustomersTableType,
-  FormattedCustomersTable,
-} from '@/app/lib/definitions';
+import { FormattedCustomersTable } from '@/app/lib/definitions';
 
 export default async function CustomersTable({
   customers,

--- a/dashboard/starter-example/app/ui/dashboard/latest-invoices.tsx
+++ b/dashboard/starter-example/app/ui/dashboard/latest-invoices.tsx
@@ -2,7 +2,7 @@ import { ArrowPathIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
 import Image from 'next/image';
 import { lusitana } from '@/app/ui/fonts';
-import { LatestInvoice } from '@/app/lib/definitions';
+
 export default async function LatestInvoices({
   latestInvoices,
 }: {

--- a/dashboard/starter-example/app/ui/dashboard/revenue-chart.tsx
+++ b/dashboard/starter-example/app/ui/dashboard/revenue-chart.tsx
@@ -1,7 +1,6 @@
 import { generateYAxis } from '@/app/lib/utils';
 import { CalendarIcon } from '@heroicons/react/24/outline';
 import { lusitana } from '@/app/ui/fonts';
-import { Revenue } from '@/app/lib/definitions';
 
 // This component is representational only.
 // For data visualization UI, check out:


### PR DESCRIPTION
Hello, this fix issue #893
Removal of the three unused definition and additional code using `error` param in the Chapter 13 in try catch will truly output
` ✔ No ESLint warnings or errors`