### PR TITLE
changing next version to latest canary version

### DIFF
--- a/dashboard/starter-example/package.json
+++ b/dashboard/starter-example/package.json
@@ -12,7 +12,7 @@
     "autoprefixer": "10.4.19",
     "bcrypt": "^5.1.1",
     "clsx": "^2.1.1",
-    "next": "^15.0.0",
+    "next": "15.0.4-canary.13",
     "next-auth": "5.0.0-beta.19",
     "postcss": "8.4.38",
     "react": "19.0.0-rc-cd22717c-20241013",


### PR DESCRIPTION
Otherwise it breaks the application on chapter 10 of the learn docs: https://nextjs.org/learn/dashboard-app/partial-prerendering , when you implement partial-prerendering incremental config.