### PR TITLE
add example query

### DIFF
--- a/dashboard/starter-example/app/query/route.ts
+++ b/dashboard/starter-example/app/query/route.ts
@@ -14,13 +14,13 @@
 // }
 
 export async function GET() {
-	return Response.json({
-		message:
-			"Uncomment this file and remove this line. You can delete this file when you are finished.",
-	});
-	// try {
-	// 	return Response.json(await listInvoices());
-	// } catch (error) {
-	// 	return Response.json({ error }, { status: 500 });
-	// }
+  return Response.json({
+    message:
+      'Uncomment this file and remove this line. You can delete this file when you are finished.',
+  });
+  // try {
+  // 	return Response.json(await listInvoices());
+  // } catch (error) {
+  // 	return Response.json({ error }, { status: 500 });
+  // }
 }

--- a/dashboard/starter-example/app/query/route.ts
+++ b/dashboard/starter-example/app/query/route.ts
@@ -1,0 +1,26 @@
+// import { db } from "@vercel/postgres";
+
+// const client = await db.connect();
+
+// async function listInvoices() {
+// 	const data = await client.sql`
+//     SELECT invoices.amount, customers.name
+//     FROM invoices
+//     JOIN customers ON invoices.customer_id = customers.id
+//     WHERE invoices.amount = 666;
+//   `;
+
+// 	return data.rows;
+// }
+
+export async function GET() {
+	return Response.json({
+		message:
+			"Uncomment this file and remove this line. You can delete this file when you are finished.",
+	});
+	// try {
+	// 	return Response.json(await listInvoices());
+	// } catch (error) {
+	// 	return Response.json({ error }, { status: 500 });
+	// }
+}


### PR DESCRIPTION
add an example `/query` route to replace the Vercel Postgres Data Browser/Query, which is not available for the other Marketplace Postgres providers (Supabase, Neon)

<img width="942" alt="Screenshot 2024-11-19 at 08 26 20" src="https://github.com/user-attachments/assets/f506b0e7-3c27-4168-b5b6-31fb94e9775e">
