### PR TITLE
Fix invalid input syntax for type integer error (#636)

### DIFF
--- a/dashboard/final-example/app/lib/actions.ts
+++ b/dashboard/final-example/app/lib/actions.ts
@@ -51,7 +51,7 @@ export async function createInvoice(prevState: State, formData: FormData) {
 
   // Prepare data for insertion into the database
   const { customerId, amount, status } = validatedFields.data;
-  const amountInCents = amount * 100;
+  const amountInCents = Math.round(amount * 100);
   const date = new Date().toISOString().split('T')[0];
 
   // Insert data into the database
@@ -91,7 +91,7 @@ export async function updateInvoice(
   }
 
   const { customerId, amount, status } = validatedFields.data;
-  const amountInCents = amount * 100;
+  const amountInCents = Math.round(amount * 100);
 
   try {
     await sql`


### PR DESCRIPTION
Fix invalid input syntax for type integer error when create or update data in database where constant amountInCents is divided by 100.

Closes (#636)