### PR TITLE
Fix: Corrected tutorial code for CardWrapper component 

### DIFF
--- a/dashboard/final-example/app/ui/dashboard/cards.tsx
+++ b/dashboard/final-example/app/ui/dashboard/cards.tsx
@@ -23,7 +23,7 @@ export default async function CardWrapper() {
   } = await fetchCardData();
 
   return (
-    <>
+    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
       <Card title="Collected" value={totalPaidInvoices} type="collected" />
       <Card title="Pending" value={totalPendingInvoices} type="pending" />
       <Card title="Total Invoices" value={numberOfInvoices} type="invoices" />
@@ -32,7 +32,7 @@ export default async function CardWrapper() {
         value={numberOfCustomers}
         type="customers"
       />
-    </>
+    </div>
   );
 }
 

--- a/dashboard/starter-example/app/ui/dashboard/cards.tsx
+++ b/dashboard/starter-example/app/ui/dashboard/cards.tsx
@@ -15,7 +15,7 @@ const iconMap = {
 
 export default async function CardWrapper() {
   return (
-    <>
+    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
       {/* NOTE: Uncomment this code in Chapter 9 */}
 
       {/* <Card title="Collected" value={totalPaidInvoices} type="collected" />
@@ -26,7 +26,7 @@ export default async function CardWrapper() {
         value={numberOfCustomers}
         type="customers"
       /> */}
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
Attached is an image of what is being rendered after replacing Card components with Suspense and CardWrapper component in chapter 9. The issue is that after deleting the initial implementation of Card component, the CardWrapper was initialized with a React Fragment instead of a styled container div.
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/90e10ed1-3073-42da-a62c-e196b480dbfe" />
