### PR TITLE
Add `pnpm.onlyBuiltDependencies` field to `package.json`

### DIFF
--- a/dashboard/final-example/package.json
+++ b/dashboard/final-example/package.json
@@ -27,5 +27,10 @@
     "@types/node": "22.10.7",
     "@types/react": "19.0.7",
     "@types/react-dom": "19.0.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "bcrypt"
+    ]
   }
 }

--- a/dashboard/starter-example/package.json
+++ b/dashboard/starter-example/package.json
@@ -27,5 +27,10 @@
     "@types/node": "22.10.7",
     "@types/react": "19.0.7",
     "@types/react-dom": "19.0.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "bcrypt"
+    ]
   }
 }


### PR DESCRIPTION
pnpm 10 blocks lifecycle scripts by default.

https://github.com/pnpm/pnpm/releases/tag/v10.0.0