### PR TITLE
fix: Add index to Pagination key for uniqueness in starter-example

### DIFF
--- a/dashboard/starter-example/app/ui/invoices/pagination.tsx
+++ b/dashboard/starter-example/app/ui/invoices/pagination.tsx
@@ -32,7 +32,7 @@ export default function Pagination({ totalPages }: { totalPages: number }) {
 
             return (
               <PaginationNumber
-                key={page}
+                key={`${page}-${index}`}
                 href={createPageURL(page)}
                 page={page}
                 position={position}


### PR DESCRIPTION
While following the dashboard tutorial, I identified that the `Pagination` component in the `starter-example` uses an incorrect `key` prop, which could cause potential issues with React's list rendering.

This issue has already been corrected in the `final-example` code, as seen in PR #640.

This pull request updates the `starter-example` to use the correct `key` prop, consistent with the fix in the `final-example` . This ensures learners starting the tutorial won't encounter this discrepancy as they uncomment the code step-by-step.
