### PR TITLE
chore: pnpm onlyBuildDependencies for bcrypt on starter

### DIFF
--- a/dashboard/final-example/middleware.ts
+++ b/dashboard/final-example/middleware.ts
@@ -6,4 +6,5 @@ export default NextAuth(authConfig).auth;
 export const config = {
   // https://nextjs.org/docs/app/building-your-application/routing/middleware#matcher
   matcher: ['/((?!api|_next/static|_next/image|.*\\.png$).*)'],
+  runtime: 'nodejs',
 };

--- a/dashboard/final-example/next.config.ts
+++ b/dashboard/final-example/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
+  experimental: {
+    nodeMiddleware: true
+  }
 };
 
 export default nextConfig;

--- a/dashboard/final-example/next.config.ts
+++ b/dashboard/final-example/next.config.ts
@@ -3,8 +3,8 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   /* config options here */
   experimental: {
-    nodeMiddleware: true
-  }
+    nodeMiddleware: true,
+  },
 };
 
 export default nextConfig;

--- a/dashboard/starter-example/next.config.ts
+++ b/dashboard/starter-example/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
+  experimental: {
+    nodeMiddleware: true
+  }
 };
 
 export default nextConfig;

--- a/dashboard/starter-example/next.config.ts
+++ b/dashboard/starter-example/next.config.ts
@@ -3,8 +3,8 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   /* config options here */
   experimental: {
-    nodeMiddleware: true
-  }
+    nodeMiddleware: true,
+  },
 };
 
 export default nextConfig;

--- a/dashboard/starter-example/package.json
+++ b/dashboard/starter-example/package.json
@@ -27,5 +27,10 @@
     "@types/node": "22.10.7",
     "@types/react": "19.0.7",
     "@types/react-dom": "19.0.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "bcrypt"
+    ]
   }
 }


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4032/update-learn-to-use-153-latest

We see that people are still having issues with `bcrypt` and `pnpm`. Let's patch the package.json on the starter to allow `bcrypt` to build. 

Maybe we should indeed consider, switching to `bcryptjs` altogether.