### PR TITLE
chore: pnpm onlyBuildDependencies for bcrypt on starter

### DIFF
--- a/dashboard/starter-example/package.json
+++ b/dashboard/starter-example/package.json
@@ -27,5 +27,10 @@
     "@types/node": "22.10.7",
     "@types/react": "19.0.7",
     "@types/react-dom": "19.0.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "bcrypt"
+    ]
   }
 }


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4032/update-learn-to-use-153-latest

Tried setting `nodejs` as runtime for middleware, but that also requires opt-into canary, and changes to `next.config.js`

I'll do that separately in another PR.