### PR TITLE
chore: add sharp to pnpm built dependencies

### DIFF
--- a/dashboard/final-example/package.json
+++ b/dashboard/final-example/package.json
@@ -30,7 +30,8 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "bcrypt"
+      "bcrypt",
+      "sharp"
     ]
   }
 }

--- a/dashboard/starter-example/package.json
+++ b/dashboard/starter-example/package.json
@@ -30,7 +30,8 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "bcrypt"
+      "bcrypt",
+      "sharp"
     ]
   }
 }


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4032/update-learn-to-use-153-latest

Complementary, also add `sharp` to be a `pnpm` built dependency.