### PR TITLE
fix: remove nodejs runtime from middleware for edge compatibility

### DIFF
--- a/dashboard/final-example/middleware.ts
+++ b/dashboard/final-example/middleware.ts
@@ -6,5 +6,4 @@ export default NextAuth(authConfig).auth;
 export const config = {
   // https://nextjs.org/docs/app/building-your-application/routing/middleware#matcher
   matcher: ['/((?!api|_next/static|_next/image|.*\\.png$).*)'],
-  runtime: 'nodejs',
 };


### PR DESCRIPTION
### Summary
This PR fixes the middleware runtime issue introduced in commit [5bea28a64d93f5f2ac6035a817a6239496786003](https://github.com/vercel/next-learn/commit/5bea28a64d93f5f2ac6035a817a6239496786003). 

- Removed `runtime: "nodejs"` from `middleware.ts` to ensure middleware runs on the Edge.
- Verified login and logout flows still work locally.

This resolves the broken live demo on https://next-learn-dashboard.vercel.sh/.

Fixes [#1091](https://github.com/vercel/next-learn/issues/1091)
