### PR TITLE
Fix chapter reference in dashboard/starter-example/app/ui/invoices/pagination.tsx comments

### DIFF
--- a/dashboard/starter-example/app/ui/invoices/pagination.tsx
+++ b/dashboard/starter-example/app/ui/invoices/pagination.tsx
@@ -6,13 +6,13 @@ import Link from 'next/link';
 import { generatePagination } from '@/app/lib/utils';
 
 export default function Pagination({ totalPages }: { totalPages: number }) {
-  // NOTE: Uncomment this code in Chapter 11
+  // NOTE: Uncomment this code in Chapter 10
 
   // const allPages = generatePagination(currentPage, totalPages);
 
   return (
     <>
-      {/*  NOTE: Uncomment this code in Chapter 11 */}
+      {/*  NOTE: Uncomment this code in Chapter 10 */}
 
       {/* <div className="inline-flex">
         <PaginationArrow


### PR DESCRIPTION
Updates misleading comments in the `Pagination` component that instructed learners to uncomment code in Chapter 11, when it should actually be uncommented in Chapter 10. See https://nextjs.org/learn/dashboard-app/adding-search-and-pagination#adding-pagination