### PR TITLE
fix(chapter-10): clarify allPages must be uncommented before JSX block

### DIFF
--- a/dashboard/starter-example/app/ui/invoices/pagination.tsx
+++ b/dashboard/starter-example/app/ui/invoices/pagination.tsx
@@ -7,12 +7,13 @@ import { generatePagination } from '@/app/lib/utils';
 
 export default function Pagination({ totalPages }: { totalPages: number }) {
   // NOTE: Uncomment this code in Chapter 10
-
+  // Step 1: Uncomment the line below before uncommenting the JSX return block
   // const allPages = generatePagination(currentPage, totalPages);
 
   return (
     <>
-      {/*  NOTE: Uncomment this code in Chapter 10 */}
+      {/* NOTE: Uncomment this code in Chapter 10 */}
+      {/* Step 2: Make sure the allPages variable above is also uncommented */}
 
       {/* <div className="inline-flex">
         <PaginationArrow


### PR DESCRIPTION
Fixes #1316

## Problem
The pagination.tsx starter file had two separate "NOTE: Uncomment this 
in Chapter 10" comments — one for the allPages variable and one for the 
JSX block below it. They appeared unrelated, so students would uncomment 
the JSX block but miss the allPages line above it, causing:

ReferenceError: allPages is not defined

## Fix
Added Step 1 / Step 2 labels to the two comments so they clearly 
reference each other. Students can no longer uncomment the JSX block 
without being pointed back to the allPages variable first.

File changed:
- dashboard/starter-example/app/ui/invoices/pagination.tsx